### PR TITLE
Added ouo.press as valid url

### DIFF
--- a/core/download/helpers.py
+++ b/core/download/helpers.py
@@ -144,7 +144,8 @@ def is_valid_link(url: str) -> bool:
         'pjointe.com/',
         'tenvoi.com/',
         'dl4free.com/',
-        'ouo.io/'
+        'ouo.io/',
+        'ouo.press/'
     ]
 
     return any([x in url.lower() for x in domains])

--- a/core/download/workers.py
+++ b/core/download/workers.py
@@ -43,8 +43,8 @@ class FilterWorker(QRunnable):
             links = self.links.toPlainText().splitlines()
             for link in links:
                 logging.debug('valid_links:'+str(link.strip()))
-                # If the shortened URL is ouo bypass, recaptcha bypass
-                if 'ouo.io' in link:
+                # If the shortened URL is ouo.io or ouo.press bypass, recaptcha bypass
+                if 'ouo.io' in link or 'ouo.press' in link:
                     link = ouo_bypass(url=link)['bypassed_link']
                     logging.debug('bypassed link: ' + str(link))
 


### PR DESCRIPTION
ouo.press is also a valid URL so the recaptcha bypasser can automatically replace "ouo.press" to "ouo.io", I have tested and its working